### PR TITLE
config.py: Use half of cores # for ASAN builds

### DIFF
--- a/IB/config.py
+++ b/IB/config.py
@@ -186,6 +186,9 @@ def setDefaults(cycle, tcTag=None):
     Configuration[cycle]['RelValArgs'] += " --job-reports --command \\\""+threaded+" --customise Validation/Performance/TimeMemorySummary.customiseWithTimeMemorySummary " + prefix + " \\\" --das-options '--cache " + environ["CMSBUILD_BUILD_DIR"] + "/das-cache.file' "
     if "ROOT6" in cycle:
       Configuration[cycle]['RelValArgs'] += " -j 6 "
+    if "ASAN" in cycle:
+      import multiprocessing
+      Configuration[cycle]['RelValArgs'] += " -j %s " % (multiprocessing.cpu_count() / 2,)
     if "THREADED" in cycle:
       Configuration[cycle]['RelValArgs'] += " -j 6 "
   if environ['CMSSW_VERSION'].startswith('CMSSW_6_2_X_SLHC_'):


### PR DESCRIPTION
Address Sanitizer (ASAN) builds are 2x slower and consumes 2x the memory.
Usual build machines configuration is 1-core/2G RAM. For ASAN we need
to run on half of cores or 1-core/4G RAM. Otherwise we might kill the
machine.

Signed-off-by: David Abdurachmanov David.Abdurachmanov@cern.ch
